### PR TITLE
Rework copying of .war into apps dir so top-level 'mvn clean install'…

### DIFF
--- a/async-websocket-application/pom.xml
+++ b/async-websocket-application/pom.xml
@@ -81,29 +81,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-				<version>2.6</version>
+                <version>2.6</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <configuration>
-                            <target>
-                                <mkdir dir="../async-websocket-wlpcfg/servers/websocketSample/apps"/>
-                                <copy file="${project.build.directory}/${project.build.finalName}.war"
-                                    tofile="../async-websocket-wlpcfg/servers/websocketSample/apps/async-websocket-application.war"/>
-                            </target>
-                        </configuration>
-                        <goals>
-                           <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/async-websocket-wlpcfg/pom.xml
+++ b/async-websocket-wlpcfg/pom.xml
@@ -38,6 +38,32 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>../async-websocket-wlpcfg/servers/websocketSample/apps</outputDirectory>
+                            <silent>true</silent>
+                            <stripVersion>true</stripVersion>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>net.wasdev.wlp.sample</groupId>
+                                    <artifactId>async-websocket-application</artifactId>
+                                    <version>1.0-SNAPSHOT</version>
+                                    <type>war</type>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
I think this better since it lets you use **_mvn clean install**_ rather than only **_mvn install**_.     

Using the **async-websocket-application** to copy the war into the server **apps** was subjecting it to the **_clean**_ of **async-websocket-wlpcfg**.
