### PR TITLE
Add a client endpoint example, and tweak the output for echo samples

### DIFF
--- a/async-websocket-application/src/main/java/net/wasdev/websocket/AnnotatedClientEndpoint.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/AnnotatedClientEndpoint.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.websocket;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.ClientEndpointConfig;
+import javax.websocket.ClientEndpointConfig.Builder;
+import javax.websocket.CloseReason;
+import javax.websocket.ContainerProvider;
+import javax.websocket.DeploymentException;
+import javax.websocket.EndpointConfig;
+import javax.websocket.OnClose;
+import javax.websocket.OnError;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+
+/**
+ * Example of an annotated WebSocket client endpoint. This looks very similar to an
+ * annotated server endpoint (no surprise), with the same lifecycle methods and 
+ * interaction patterns.
+ * 
+ * Creating a {@link ClientEndpoint} can feel a little strange. You add the 
+ * annotation, but still need to actually create the endpoint, as shown in 
+ * {@link #connect(URI)}.
+ *
+ */
+@ClientEndpoint
+public class AnnotatedClientEndpoint {
+	
+	public static final String NEW_CLIENT = "client:";
+	static AtomicInteger clientId = new AtomicInteger(0);
+
+	// try to stick to one client connection for this sample.
+	private static AtomicReference<Session> clientConnection = new AtomicReference<>(null);
+	
+    public static ClientEndpointConfig getDefaultConfig() {
+        Builder b = ClientEndpointConfig.Builder.create();
+        return b.build();
+    }
+    
+    public static void connect(String clientString) throws IOException {
+    	if (clientString.startsWith(NEW_CLIENT) ) {
+    		clientString = clientString.substring(NEW_CLIENT.length());
+
+        	WebSocketContainer c = ContainerProvider.getWebSocketContainer();
+    		Hello.log(AnnotatedClientEndpoint.class, "Starting the client for " + clientString);
+
+    		URI uriServerEP = URI.create(clientString);
+    		try {
+    			Session s = c.connectToServer(AnnotatedClientEndpoint.class, uriServerEP);
+
+    			// we're just going to maintain one client at a time, so reading the output
+    			// can be somewhat sane.. Set the new session, and close the old one.
+    			s = clientConnection.getAndSet(s);
+    			if ( s != null )
+    				s.close();
+    		} catch (DeploymentException e) {
+    			e.printStackTrace();
+    		}
+    	}
+    }
+    
+	int id = clientId.incrementAndGet();
+
+
+	@OnOpen
+	public void onOpen(Session session, EndpointConfig ec) {
+		// (lifecycle) Called when the connection is opened
+		Hello.log(this, "Client "+ id +" open!");
+		
+        try {
+			session.getBasicRemote().sendText("Client "+ id +" started");
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@OnClose
+	public void onClose(Session session, CloseReason reason) {
+		// (lifecycle) Called when the connection is closed
+		Hello.log(this, "Client "+ id +" closed!");
+		
+		// remove this session if it was the client session we were keeping around
+		clientConnection.compareAndSet(session, null);
+	}
+
+	@OnMessage
+	public void receiveMessage(String message, Session session) throws IOException {
+		// Called when a message is received. 
+		// Single endpoint per connection by default --> @OnMessage methods are single threaded!
+		// Endpoint/per-connection instances can see each other through sessions.
+
+		if ("stop".equals(message)) {
+			Hello.log(this, "Client "+ id +" stopped, " + this);
+			session.close();
+		} else if (message.contains("client ") && message.contains("forwarded")) {
+			Hello.log(this, "Client "+ id +" received: " + message);
+			message = message.replace(" (forwarded)", ""); // strip the forwarded bit off.
+			int pos = message.indexOf("client "); // strip the client bit off
+			session.getBasicRemote().sendText("Client "+ id +" echo: " + message.substring(pos + 7));
+		} else {
+			Hello.log(this, "Client "+ id +" received: " + message);
+		}
+	}
+
+	@OnError
+	public void onError(Throwable t) {
+		// (lifecycle) Called if/when an error occurs and the connection is disrupted
+		Hello.log(this, "oops: " + t);
+	}
+}

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/AnnotatedClientEndpoint.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/AnnotatedClientEndpoint.java
@@ -80,6 +80,7 @@ public class AnnotatedClientEndpoint {
 		}
 	}
 
+	/** Instance id -- used to identify the client in the logs */
 	int id = clientId.incrementAndGet();
 
 

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/AnnotatedClientEndpoint.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/AnnotatedClientEndpoint.java
@@ -41,7 +41,7 @@ import javax.websocket.WebSocketContainer;
  * 
  * Creating a {@link ClientEndpoint} can feel a little strange. You add the 
  * annotation, but still need to actually create the endpoint, as shown in 
- * {@link #connect(URI)}.
+ * {@link #connect(String)}.
  *
  */
 @ClientEndpoint

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/AnnotatedClientEndpoint.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/AnnotatedClientEndpoint.java
@@ -46,40 +46,40 @@ import javax.websocket.WebSocketContainer;
  */
 @ClientEndpoint
 public class AnnotatedClientEndpoint {
-	
+
 	public static final String NEW_CLIENT = "client:";
 	static AtomicInteger clientId = new AtomicInteger(0);
 
 	// try to stick to one client connection for this sample.
 	private static AtomicReference<Session> clientConnection = new AtomicReference<>(null);
-	
-    public static ClientEndpointConfig getDefaultConfig() {
-        Builder b = ClientEndpointConfig.Builder.create();
-        return b.build();
-    }
-    
-    public static void connect(String clientString) throws IOException {
-    	if (clientString.startsWith(NEW_CLIENT) ) {
-    		clientString = clientString.substring(NEW_CLIENT.length());
 
-        	WebSocketContainer c = ContainerProvider.getWebSocketContainer();
-    		Hello.log(AnnotatedClientEndpoint.class, "Starting the client for " + clientString);
+	public static ClientEndpointConfig getDefaultConfig() {
+		Builder b = ClientEndpointConfig.Builder.create();
+		return b.build();
+	}
 
-    		URI uriServerEP = URI.create(clientString);
-    		try {
-    			Session s = c.connectToServer(AnnotatedClientEndpoint.class, uriServerEP);
+	public static void connect(String clientString) throws IOException {
+		if (clientString.startsWith(NEW_CLIENT) ) {
+			clientString = clientString.substring(NEW_CLIENT.length());
 
-    			// we're just going to maintain one client at a time, so reading the output
-    			// can be somewhat sane.. Set the new session, and close the old one.
-    			s = clientConnection.getAndSet(s);
-    			if ( s != null )
-    				s.close();
-    		} catch (DeploymentException e) {
-    			e.printStackTrace();
-    		}
-    	}
-    }
-    
+			WebSocketContainer c = ContainerProvider.getWebSocketContainer();
+			Hello.log(AnnotatedClientEndpoint.class, "Starting the client for " + clientString);
+
+			URI uriServerEP = URI.create(clientString);
+			try {
+				Session s = c.connectToServer(AnnotatedClientEndpoint.class, uriServerEP);
+
+				// we're just going to maintain one client at a time, so reading the output
+				// can be somewhat sane.. Set the new session, and close the old one.
+				s = clientConnection.getAndSet(s);
+				if ( s != null )
+					s.close();
+			} catch (DeploymentException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
 	int id = clientId.incrementAndGet();
 
 
@@ -87,8 +87,8 @@ public class AnnotatedClientEndpoint {
 	public void onOpen(Session session, EndpointConfig ec) {
 		// (lifecycle) Called when the connection is opened
 		Hello.log(this, "Client "+ id +" open!");
-		
-        try {
+
+		try {
 			session.getBasicRemote().sendText("Client "+ id +" started");
 		} catch (IOException e) {
 			e.printStackTrace();
@@ -99,7 +99,7 @@ public class AnnotatedClientEndpoint {
 	public void onClose(Session session, CloseReason reason) {
 		// (lifecycle) Called when the connection is closed
 		Hello.log(this, "Client "+ id +" closed!");
-		
+
 		// remove this session if it was the client session we were keeping around
 		clientConnection.compareAndSet(session, null);
 	}

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/EchoAsyncEndpoint.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/EchoAsyncEndpoint.java
@@ -56,8 +56,8 @@ import javax.websocket.server.ServerEndpoint;
 public class EchoAsyncEndpoint {
 
 	static AtomicInteger endpointId = new AtomicInteger(0);
-	static String format = "Endpoint %d, message %d: %s";
-	static String delay = "Endpoint %d, delayed message %d: %s";
+	static String format = "[ep=%d, msg=%d]: %s";
+	static String delay = "[ep=%d, msg=%d]: %s (delayed)";
 	
 	/** CDI injection of Java EE7 Managed executor service */
 	@Resource
@@ -72,6 +72,7 @@ public class EchoAsyncEndpoint {
 	public void onOpen(Session session, EndpointConfig ec) {
 		// (lifecycle) Called when the connection is opened
 		Hello.log(this, "Endpoint " + endptId + " is open!");
+		session.getUserProperties().put("endptId", endptId);
 	}
 
 	@OnClose
@@ -123,7 +124,7 @@ public class EchoAsyncEndpoint {
 
 				if ( s.isOpen()) { // double check: ensure session is still open
 					// log and send
-					Hello.log(this, "Sending to " + m);
+					Hello.log(this, "Sending to Endpoint " + s.getUserProperties().get("endptId") + ": " + m);
 					s.getBasicRemote().sendText(m);
 				}
 			} catch (IOException e) {

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/EchoAsyncEndpoint.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/EchoAsyncEndpoint.java
@@ -81,7 +81,10 @@ public class EchoAsyncEndpoint {
 		Hello.log(this, "Endpoint " + endptId + " is closed!");
 	}
 
+	/** message id: incremented as messages are received by this endpoint */
 	int count = 0;
+
+	/** Instance id -- used to identify this endpoint in the logs */
 	int endptId = endpointId.incrementAndGet();
 
 	@OnMessage

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/EchoCommon.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/EchoCommon.java
@@ -1,0 +1,43 @@
+package net.wasdev.websocket;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.websocket.Session;
+
+public class EchoCommon {
+	static AtomicInteger endpointId = new AtomicInteger(0);
+	static String format = "[ep=%d, msg=%d]: %s";
+
+	/** Instance id -- used to identify this endpoint in the logs */
+	int endptId = endpointId.incrementAndGet();
+
+	
+	void broadcast(Session session, int id, String message) {
+		
+		// Look, Ma! Broadcast!
+		// Easy as pie to send the same data around to different sessions.
+		for (Session s : session.getOpenSessions()) {
+			try {
+				// Do some munging of the message... 
+				// If the message is heading for a different session than it started from, indicate
+				// it is a forwarded message by appending " (forwarded)"
+				String m = ( s != session ) ? message + " (forwarded)" : message;
+				
+				// Now format it consistently
+				m = String.format(format, endptId, id, m);
+
+				if ( s.isOpen()) { 
+					// double check: ensure session is still open, and log and send
+					Hello.log(this, "--> ep=" + s.getUserProperties().get("endptId") + ": " + m);
+					s.getBasicRemote().sendText(m);
+				}
+			} catch (IOException e) {
+				try {
+					s.close();
+				} catch (IOException e1) {
+				}
+			}
+		}
+	}
+}

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/EchoEndpoint.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/EchoEndpoint.java
@@ -66,7 +66,10 @@ public class EchoEndpoint {
 		Hello.log(this, "Endpoint " + endptId + " is closed!");
 	}
 
+	/** message id: incremented as messages are received by this endpoint */
 	int count = 0;
+
+	/** Instance id -- used to identify this endpoint in the logs */
 	int endptId = endpointId.incrementAndGet();
 
 	@OnMessage

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/EndpointApplicationConfig.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/EndpointApplicationConfig.java
@@ -45,14 +45,19 @@ public class EndpointApplicationConfig implements ServerApplicationConfig {
 
 	/**
 	 * Create configurations for programmatic endpoints that should be
-	 * deployed using a . The string value is the URI relative to your app’s
-	 * context root, similar to the value provided in the @ServerEndpoint
-	 * annotation, e.g. the context root for this example application
-	 * is <code>websocket</code>, which makes the WebSocket URL used to
-	 * reach this endpoint
-	 * <code>ws://localhost/websocket/ExtendedEndpoint</code>.
+	 * deployed. 
+	 * <p>
+	 * The string value passed to the {@link ServerEndpointConfig.Builder} 
+	 * is the URI relative to your app’s context root, similar to the 
+	 * value provided in the @ServerEndpoint annotation, e.g. the context 
+	 * root for this example application is <code>websocket</code>, and the string
+	 * provided to build the {@link ServerEndpointConfig} is <code>/ProgrammaticEndpoint</code>, 
+	 * which makes the WebSocket URL used to reach the endpoint
+	 * <code>ws://localhost/websocket/ProgrammaticEndpoint</code>.
+	 * </p><p>
 	 * The ServerEndpointConfig can also be used to configure additional
 	 * protocols, and extensions.
+	 * </p>
 	 *
 	 * @param endpointClasses
 	 *            the set of all the Endpoint classes in the archive containing

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/Hello.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/Hello.java
@@ -1,10 +1,10 @@
 package net.wasdev.websocket;
 
 public class Hello {
-	static final String format = "%-60s - %s";
+	static final String format = "%-30s - %s";
 	
 	public static void log(Object source, String message) {
-		System.out.println(String.format(format, source == null ? "null" : source.toString(), message));
+		System.out.println(String.format(format, source == null ? "null" : source.getClass().getSimpleName(), message));
 	}
 }
 

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/Hello.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/Hello.java
@@ -1,10 +1,12 @@
 package net.wasdev.websocket;
 
+import javax.websocket.Session;
+
 public class Hello {
-	static final String format = "%-30s - %s";
+	static final String log_format = "%-30s - %s";
 	
 	public static void log(Object source, String message) {
-		System.out.println(String.format(format, source == null ? "null" : source.getClass().getSimpleName(), message));
+		System.out.println(String.format(log_format, source == null ? "null" : source.getClass().getSimpleName(), message));
 	}
 }
 

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/ProgrammaticEndpoint.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/ProgrammaticEndpoint.java
@@ -28,7 +28,7 @@ import javax.websocket.server.ServerApplicationConfig;
 import javax.websocket.server.ServerEndpointConfig;
 
 /**
- * Example of a WebSocket server endpoint programatically. It needs to be
+ * Example of a programmatic WebSocket server endpoint. It needs to be
  * configured using {@link ServerApplicationConfig}.See
  * {@link ExtendedEndpointApplicationConfig}.
  * <p>

--- a/async-websocket-application/src/main/webapp/META-INF/MANIFEST.MF
+++ b/async-websocket-application/src/main/webapp/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Class-Path: 
+

--- a/async-websocket-application/src/main/webapp/index.html
+++ b/async-websocket-application/src/main/webapp/index.html
@@ -35,6 +35,7 @@
             '<p>This sample sends simple messages (that you provide) to the server. '
             + 'The server then sends back what it receives (only to this session).</p>'
             + "<p>Sending 'stop' prompts the server to close the connection."
+            + "<br />Sending 'clear' will clear the activity shown below."
             + '<br/>The server endpoint for this sample is a simple POJO with annotations.</p>');
         return false;
     };
@@ -56,7 +57,8 @@
             '<p>This sample sends simple messages (that you provide) to the server. '
             + 'The server then broadcasts what it receives to all established sessions.</p>'
             + "<p>Sending 'stop' prompts the server to close the connection."
-            + "<br />Sending 'clear' will clear the activity shown below."
+            + "<br />'client' will open a client session, any other message containing 'client' will cause the client to echo the message."
+            + "<br />'clear' will clear the activity shown below."
             + '<br/>The server endpoint for this sample is a simple POJO with annotations.</p>');
         return false;
     };
@@ -68,7 +70,8 @@
             + 'The server then broadcasts what it receives to all established sessions '
             + 'and queues an executor to re-broadcast that message after a small delay.</p>'
             + "<p>Sending 'stop' prompts the server to close the connection."
-            + "<br />Sending 'clear' will clear the activity shown below."
+            + "<br />'client' will open a client session, any other message containing 'client' will cause the client to echo the message."
+            + "<br />'clear' will clear the activity shown below."
             + '<br/>The server endpoint for this sample is a simple POJO with annotations.</p>');
         return false;
     };

--- a/async-websocket-application/src/main/webapp/websocketClient.js
+++ b/async-websocket-application/src/main/webapp/websocketClient.js
@@ -36,6 +36,9 @@ function send() {
 	
 	if ( txt.indexOf('clear') >= 0) {
 		document.getElementById('messages').innerHTML='';
+	} else if ( txt === 'client' ) {
+		// client alone will initiate a programmatic client in the server
+		sendSocket('client:'+websocket_url);
 	} else if ( use_encoder ) {
 		json = {'content' : txt };
 		sendSocket(JSON.stringify(json));

--- a/docs/Building-the-sample.md
+++ b/docs/Building-the-sample.md
@@ -15,7 +15,7 @@ async-websocket-wlpcfg
 
 ## Building with Gradle
 
-This sample can be build using [Gradle](http://gradle.org/).
+This sample can be built using [Gradle](http://gradle.org/).
 
 ```bash
 $ gradle build publishToMavenLocal
@@ -23,7 +23,7 @@ $ gradle build publishToMavenLocal
 
 ## Building with maven
 
-This sample can be build using [Apache Maven](http://maven.apache.org/).
+This sample can be built using [Apache Maven](http://maven.apache.org/).
 
 ```bash
 $ mvn install

--- a/docs/Using-WDT.md
+++ b/docs/Using-WDT.md
@@ -1,4 +1,4 @@
-### Eclipse / WDT
+## Eclipse / WDT
 
 The WebSphere Development Tools (WDT) for Eclipse can be used to control the server (start/stop/dump/etc.), it also supports incremental publishing with minimal restarts, working with a debugger to step through your applications, etc.
 
@@ -11,7 +11,7 @@ Installing WDT on Eclipse is as simple as a drag-and-drop, but the process is ex
 
 [wasdev-wdt]: https://developer.ibm.com/wasdev/downloads/liberty-profile-using-eclipse/
 
-#### Clone Git Repo
+### Clone Git Repo
 
 If the sample git repository hasn't been cloned yet, WDT has git tools integrated into the IDE:
 
@@ -23,7 +23,7 @@ If the sample git repository hasn't been cloned yet, WDT has git tools integrate
 4.  The git repo url should already be filled in.  Select *Next -> Next -> Finish*
 5.  The "sample.async.websockets [master]" repo should appear in the view
 
-#### Import Gradle projects into WDT
+### Import Gradle projects into WDT
 
 This assumes you have the Gradle IDE tools installed into Eclipse.
 
@@ -35,7 +35,10 @@ This assumes you have the Gradle IDE tools installed into Eclipse.
 6. Select all the projects (there should be three) and click *Finish*
 7.  This will create 3 projects in Eclipse: async-websocket, async-websocket-application, and async-websocket-wlpcfg
 
-#### Import Maven projects into WDT
+:star: *Note:* If you did not use Eclipse/WDT to clone the git repository, follow from step 3, but navigate to the cloned repository directory rather than pasting its name in step 4.
+
+
+### Import Maven projects into WDT
 
 1.  In the Git Repository view, expand the websocket repo to see the "Working Directory" folder
 2.  Right-click on this folder, and select *Copy path to Clipboard*
@@ -44,13 +47,14 @@ This assumes you have the Gradle IDE tools installed into Eclipse.
 5.  Select *Browse...* button and select *Finish* (confirm it finds 3 pom.xml files)
 6.  This will create 3 projects in Eclipse: async-websocket, async-websocket-application, and async-websocket-wlpcfg
 
-:star: *Note:* If you did not use Eclipse/WDT to clone the git repository, follow from step 3, but navigate to the cloned repository directory rather than pasting its name.
+:star: *Note:* If you did not use Eclipse/WDT to clone the git repository, follow from step 3, but navigate to the cloned repository directory rather than pasting its name in step 4.
 
-#### Create a Runtime Environment and a Liberty Server
+### Create a Runtime Environment and a Liberty Server
 
 For the purposes of this sample, we will create the Liberty server (step 3 in the wasdev.net instructions) a little differently to create and customize a Runtime Environment that will allow the server to directly use the configuraiton in the `async-websocket-wlp` project.
 
-##### Create a Runtime Environment in Eclipse
+#### Create a Runtime Environment in Eclipse
+
 1. Open the 'Runtime Explorer' view:
     * *Window -> Show View -> Other*
     * type `runtime` in the filter box to find the view (it's under the Server heading).
@@ -61,26 +65,29 @@ For the purposes of this sample, we will create the Liberty server (step 3 in th
     * select *Install from an archive or a repository* to download a new Liberty archive.
 5. Follow the prompts (and possibly choose additional features to install) until you *Finish* creating the Runtime Environment
 
-##### Add the User directory from the maven or Gradle project, and create a server
+#### Add the User directory from the maven or Gradle project, and create a server
+
 1. Right-click on the Runtime Environment created above in the 'Runtime Explorer' view, and select *Edit*
 2. Click the `Advanced Options...` link
 3. If the `async-websocket-wlpcfg` directory is not listed as a User Directory, we need to add it:
     1. Click New
     2. Select the `async-websocket-wlpcfg` project
     3. Select *Finish*, *OK*, *Finish*
-4. Right-click on the `async-websocket-wlpcfg` user directory listed under the target Runtime Environment in the Runtime Explorer view., and select *New Server*.
-5. The resulting dialog should be pre-populated with the websocketSample Liberty profile server.
+4. Right-click on the `async-websocket-wlpcfg` user directory listed under the target Runtime Environment in the Runtime Explorer view, and select *New Server*.
+5. The resulting dialog should be pre-populated with the `websocketSample` Liberty profile server.
+   The default name for this server can vary, you might also opt to rename it from the Right-click menu in the Servers view to make it easier to identify.
 6. Click *Finish*
 
 #### Running Liberty and the sample application from WDT
 
 1.  Select the `async-websocket-application` project
 2.  Right-click -> *Run As... -> Run On Server*
-3.  Select the "WebShere Application Server under localhost" folder, and select *Finish*
+3.  Select the appropriate server (as created above) and select *Finish*
 4.  Confirm web browser opens on "http://localhost:9082/websocket/" with 5 hyperlinks to run samples
+
+* Note: Some versions of WDT incorrectly map the cdi-1.2 dependency to the CDI 1.0 Facet, which prevents the *Run As ...* operation in step 2 from succeeding. If this happens, Right-click on the `async-websocket-application` project, and select *Properties*, then select *Project Facets* in the left-hand pane. Change the the "Context and dependency injection (CDI)" facet to use version 1.2, at which point, step 2 (above) should work.
 
 
 ## Tips
 
 * When importing the existing maven project into Eclipse, Eclipse will (by default) "helpfully" add this project to an (extraneous) ear. To turn this off, go to Preferences -> Java EE -> Project, and uncheck "Add project to an EAR" before you import the project. If you forgot to do this, just delete the ear project; no harm.
-


### PR DESCRIPTION
The echo samples were somewhat unclear about what output was coming from (or being echoed to) where, so I've tried to clarify that with changes to the message formatting to show which messages are being forwarded from other sessions vs. being echoed back to the originating session.

Tweaks were made to the javascript (to allow a client to be started), and to the html (for instructions).

An empty manifest was checked in because maven kept generating it anyway.
