### PR TITLE
 Comment corrections, use common endpoint id for encoder sample

### DIFF
--- a/async-websocket-application/src/main/java/net/wasdev/websocket/EchoCommon.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/EchoCommon.java
@@ -5,6 +5,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.websocket.Session;
 
+/**
+ * Common class that helps identify endpoints when running the sample and 
+ * observing output.
+ */
 public class EchoCommon {
 	static AtomicInteger endpointId = new AtomicInteger(0);
 	static String format = "[ep=%d, msg=%d]: %s";
@@ -13,6 +17,16 @@ public class EchoCommon {
 	int endptId = endpointId.incrementAndGet();
 
 	
+	/**
+	 * Simple text based broadcast. 
+	 * This does some additional munging of the message text, to make it more
+	 * obvious where the message originated (is an endpoint getting its own
+	 * message back, or has it been forwarded from another endpoint).
+	 * 
+	 * @param session
+	 * @param id
+	 * @param message
+	 */
 	void broadcast(Session session, int id, String message) {
 		
 		// Look, Ma! Broadcast!
@@ -20,8 +34,12 @@ public class EchoCommon {
 		for (Session s : session.getOpenSessions()) {
 			try {
 				// Do some munging of the message... 
-				// If the message is heading for a different session than it started from, indicate
-				// it is a forwarded message by appending " (forwarded)"
+				// If the message is heading for a different session/endpoint than it started from, 
+				// indicate it is a forwarded message by appending " (forwarded)"
+				// Note that it can be easier to code clients to always react to messages as they 
+				// are returned over the socket, rather than dealing separately with messages they
+				// sent. If you don't want messages to go back to the sender, you can use the same check
+				// to skip routing back to the sender entirely.
 				String m = ( s != session ) ? message + " (forwarded)" : message;
 				
 				// Now format it consistently

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/EchoEncoderEndpoint.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/EchoEncoderEndpoint.java
@@ -34,7 +34,7 @@ import javax.websocket.server.ServerEndpoint;
  * to the sender), using the {@link EchoEncoder} to serialize the outbound payload.
  * 
  * <p>
- * The value is the URI relative to your app’s context root,  e.g. the context
+ * The value is the URI relative to your app’s context root,e.g. the context
  * root for this application is <code>websocket</code>, which makes the
  * WebSocket URL used to reach this endpoint
  * <code>ws://localhost/websocket/EchoEncoderEndpoint</code>.
@@ -49,17 +49,27 @@ import javax.websocket.server.ServerEndpoint;
  * </p>
  */
 @ServerEndpoint(value = "/EchoEncoderEndpoint", decoders = EchoDecoder.class, encoders = EchoEncoder.class)
-public class EchoEncoderEndpoint {
+public class EchoEncoderEndpoint extends EchoCommon {
 
+	/**
+	 * @param session Session for established WebSocket
+	 * @param ec endpoint configuration
+	 * 
+	 * @see EchoCommon#endptId
+	 */
 	@OnOpen
 	public void onOpen(Session session, EndpointConfig ec) {
-		// (lifecycle) Called when the connection is opened
-		Hello.log(this, "I'm open!");
+		// (lifecycle) Called when the connection is opened.
+		Hello.log(this, "Endpoint " + endptId + " is open!");
+
+		// Store the endpoint id in the session so that when we log and push 
+		// messages around, we have something more user-friendly to look at.
+		session.getUserProperties().put("endptId", endptId);
 	}
 
 	@OnClose
 	public void onClose(Session session, CloseReason reason) {
-		Hello.log(this, "I'm closed!");
+		Hello.log(this, "Endpoint " + endptId + " is closed!");
 	}
 
 	/**

--- a/async-websocket-application/src/main/java/net/wasdev/websocket/EchoEndpoint.java
+++ b/async-websocket-application/src/main/java/net/wasdev/websocket/EchoEndpoint.java
@@ -34,7 +34,7 @@ import javax.websocket.server.ServerEndpoint;
  * to the sender).
  * 
  * <p>
- * The value is the URI relative to your app’s context root,  e.g. the context
+ * The value is the URI relative to your app’s context root, e.g. the context
  * root for this application is <code>websocket</code>, which makes the
  * WebSocket URL used to reach this endpoint
  * <code>ws://localhost/websocket/EchoEndpoint</code>.


### PR DESCRIPTION
Bad whitespace character in two headers, make consistent some javadoc between endpoints.
Make the EchoEncoderEndpoint also extend EchoCommon so the endpoints identify in the same way.
