### PR TITLE
Fix Gradle Typo, and off-by-one subdir to wlp location

### DIFF
--- a/async-websocket-application/pom.xml
+++ b/async-websocket-application/pom.xml
@@ -264,7 +264,7 @@
             <id>check-liberty-present</id>
             <activation>
                 <file>
-                    <exists>${libertyRoot}/wlp/lib/ws-launch.jar</exists>
+                    <exists>${libertyRoot}/lib/ws-launch.jar</exists>
                 </file>
             </activation>
             <properties>

--- a/docs/Using-WDT.md
+++ b/docs/Using-WDT.md
@@ -51,7 +51,7 @@ This assumes you have the Gradle [Buildship](https://projects.eclipse.org/projec
 ###### Run Gradle build
 
 1. Right-click on async-websocket/build.gradle
-2. *Run As > Gradnle Build...*
+2. *Run As > Gradle Build...*
 3. In the *Gradle Tasks* section enter "build"
 4. Click *Run*
 


### PR DESCRIPTION
Looks like the ci.maven 'installDirectory' includes the 'wlp' at the end:  /my/home/wlp.    But the location in the 'check-liberty-present' profile is pointing to the dir containing 'wlp'.
